### PR TITLE
Fix(nav): Add 'About Us' link to header and fix page styling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,7 @@ import Footer from './components/Footer';
 import HomePage from './pages/HomePage';
 import EventsPage from './pages/EventsPage';
 import EventDetailPage from './pages/EventDetailPage';
-
+import AboutUs from './pages/AboutUs';
 const App: React.FC = () => {
   return (
     <HashRouter>
@@ -17,6 +17,7 @@ const App: React.FC = () => {
             <Route path="/" element={<HomePage />} />
             <Route path="/events" element={<EventsPage />} />
             <Route path="/event/:id" element={<EventDetailPage />} />
+            <Route path="/about" element={<AboutUs />} />
           </Routes>
         </main>
         <Footer />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -30,6 +30,16 @@ const Header: React.FC = () => {
               Events
             </NavLink>
           </li>
+          <li>
+            <NavLink 
+              to="/about" 
+              className={({ isActive }) => 
+                `text-base font-medium transition-colors ${isActive ? 'text-primary' : 'hover:text-primary'}`
+              }
+            >
+              About Us
+            </NavLink>
+          </li>
         </ul>
       </nav>
     </header>

--- a/pages/AboutUs.jsx
+++ b/pages/AboutUs.jsx
@@ -1,63 +1,71 @@
 import React from "react";
+import { Link } from "react-router-dom"; // Use Link for internal navigation
 
 const AboutUs = () => {
-    return (
-        <div className="max-w-5xl mx-auto px-6 py-12">
-            <h1 className="text-4xl font-bold text-center mb-8">About Us</h1>
+  return (
+    <div className="max-w-5xl mx-auto px-6 py-12">
+      <h1 className="text-4xl font-bold text-center mb-8">About Us</h1>
 
-            <section className="mb-10">
-                <p className="text-lg text-gray-700 leading-relaxed mb-6">
-                    Welcome to our platform! We are passionate about creating meaningful
-                    experiences through events that connect people, spark creativity, and
-                    inspire growth.
-                </p>
-                <p className="text-lg text-gray-700 leading-relaxed">
-                    Our mission is to make event discovery and participation simple,
-                    engaging, and rewarding. Whether you are looking to attend workshops,
-                    conferences, or community gatherings, we provide a space where
-                    opportunities meet people.
-                </p>
-            </section>
+      {/* Main description section */}
+      <section className="mb-10">
+        <p className="text-lg text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+          Welcome to our platform! We are passionate about creating meaningful
+          experiences through events that connect people, spark creativity, and
+          inspire growth.
+        </p>
+        <p className="text-lg text-gray-700 dark:text-gray-300 leading-relaxed">
+          Our mission is to make event discovery and participation simple,
+          engaging, and rewarding. Whether you are looking to attend workshops,
+          conferences, or community gatherings, we provide a space where
+          opportunities meet people.
+        </p>
+      </section>
 
-            <section className="grid md:grid-cols-3 gap-8 text-center">
-                <div className="p-6 bg-white rounded-2xl shadow">
-                    <h2 className="text-xl font-semibold mb-3">Our Vision</h2>
-                    <p className="text-gray-600">
-                        To empower individuals and communities by connecting them with
-                        transformative events and experiences.
-                    </p>
-                </div>
-                <div className="p-6 bg-white rounded-2xl shadow">
-                    <h2 className="text-xl font-semibold mb-3">Our Values</h2>
-                    <p className="text-gray-600">
-                        We believe in inclusivity, innovation, and collaboration as the
-                        foundation for every event we support.
-                    </p>
-                </div>
-                <div className="p-6 bg-white rounded-2xl shadow">
-                    <h2 className="text-xl font-semibold mb-3">Our Promise</h2>
-                    <p className="text-gray-600">
-                        To deliver reliable, user-friendly tools that make attending and
-                        organizing events stress-free.
-                    </p>
-                </div>
-            </section>
-
-            <section className="mt-12 text-center">
-                <h2 className="text-2xl font-bold mb-4">Join Us on This Journey</h2>
-                <p className="text-gray-700 mb-6">
-                    Together, we can create moments that matter. Explore our events and
-                    become part of a growing community.
-                </p>
-                <a
-                    href="/events"
-                    className="px-6 py-3 bg-blue-600 text-white rounded-lg shadow hover:bg-blue-700 transition"
-                >
-                    Explore Events
-                </a>
-            </section>
+      {/* Vision, Values, Promise cards */}
+      <section className="grid md:grid-cols-3 gap-8 text-center">
+        {/* Card 1 */}
+        <div className="p-6 bg-light-card dark:bg-dark-card rounded-2xl shadow">
+          <h2 className="text-xl font-semibold mb-3">Our Vision</h2>
+          <p className="text-gray-600 dark:text-gray-300">
+            To empower individuals and communities by connecting them with
+            transformative events and experiences.
+          </p>
         </div>
-    );
+        {/* Card 2 */}
+        <div className="p-6 bg-light-card dark:bg-dark-card rounded-2xl shadow">
+          <h2 className="text-xl font-semibold mb-3">Our Values</h2>
+          <p className="text-gray-600 dark:text-gray-300">
+            We believe in inclusivity, innovation, and collaboration as the
+            foundation for every event we support.
+          </p>
+        </div>
+        {/* Card 3 */}
+        <div className="p-6 bg-light-card dark:bg-dark-card rounded-2xl shadow">
+          <h2 className="text-xl font-semibold mb-3">Our Promise</h2>
+          <p className="text-gray-600 dark:text-gray-300">
+            To deliver reliable, user-friendly tools that make attending and
+            organizing events stress-free.
+          </p>
+        </div>
+      </section>
+
+      {/* "Join Us" section */}
+      <section className="mt-12 text-center">
+        <h2 className="text-2xl font-bold mb-4">Join Us on This Journey</h2>
+        <p className="text-gray-700 dark:text-gray-300 mb-6">
+          Together, we can create moments that matter. Explore our events and
+          become part of a growing community.
+        </p>
+        {/* Use Link component for internal routing */}
+        <Link
+          to="/events"
+          className="px-6 py-3 bg-primary text-white rounded-lg shadow hover:bg-primary-hover transition"
+        >
+          Explore Events
+        </Link>
+      </section>
+    </div>
+  );
 };
 
 export default AboutUs;


### PR DESCRIPTION
Closes #10

This PR completes the "About Us" page feature by making it accessible to users and fixing its styling.

What this PR does:
1.  **Adds the Route:** Includes the `/about` route in `App.tsx` to make the `AboutUs` page reachable.
2.  **Updates Header:** Adds the "About Us" link to the main navigation in `Header.tsx`.
3.  **Fixes Styling:** Updates the styling in `AboutUs.jsx` to be consistent with the site's theme and adds the correct dark mode styles, making the page readable.


<img width="1919" height="1020" alt="Screenshot 2025-10-18 140859" src="https://github.com/user-attachments/assets/894102dd-7660-4f34-8de3-db574f59edcf" />
<img width="1903" height="992" alt="Screenshot 2025-10-18 140935" src="https://github.com/user-attachments/assets/6c4b1982-050a-43d3-9982-3807e7253950" />

The page is now fully functional and styled correctly.